### PR TITLE
Revamp interface visuals and interactions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -3,7 +3,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const input = document.getElementById('question-input');
     const questionBubble = document.getElementById('question-bubble');
     const techList = document.getElementById('technology-list');
-    const responseArea = document.getElementById('response-area');
     const tooltip = document.getElementById('tooltip');
 
     form.addEventListener('submit', async (e) => {
@@ -17,26 +16,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         questionBubble.textContent = question;
         questionBubble.style.display = 'inline-block';
+        input.value = '';
         techList.innerHTML = '';
-        data.technologies.forEach(t => {
+        techList.style.display = 'block';
+        data.technologies.forEach((t, idx) => {
             const li = document.createElement('li');
             li.textContent = t.name;
             li.dataset.segment = t.segment;
             li.dataset.instruments = t.instruments.join(', ');
+            li.classList.add('float-in');
+            li.style.animationDelay = `${idx * 0.3}s`;
             techList.appendChild(li);
         });
-    });
-
-    responseArea.addEventListener('mouseenter', () => {
-        if (questionBubble.style.display !== 'none') {
-            techList.style.display = 'block';
-        }
-    });
-
-    responseArea.addEventListener('mouseleave', () => {
-        techList.style.display = 'none';
-        hideTooltip();
-        clearHighlight();
     });
 
     techList.addEventListener('mouseover', (e) => {

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,19 @@
 body {
     font-family: Arial, sans-serif;
-    margin: 20px;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+#question-form {
+    margin-bottom: 15px;
+}
+
+#response-area {
+    text-align: center;
 }
 
 #technology-list {
@@ -12,16 +25,39 @@ body {
 #technology-list li {
     margin: 5px 0;
     cursor: pointer;
+    opacity: 0;
+}
+
+.float-in {
+    animation: float-in 0.6s ease forwards;
+}
+
+@keyframes float-in {
+    from {
+        transform: translateY(20px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
 }
 
 .segment {
-    fill: #ccc;
-    opacity: 0.3;
+    opacity: 0.6;
 }
 
+#segment-discovery { fill: #d9f0ff; }
+#segment-tech-trigger { fill: #bfe2ff; }
+#segment-hype-peak { fill: #a5d4ff; }
+#segment-disillusionment { fill: #8bc7ff; }
+#segment-enlightenment { fill: #71b9ff; }
+#segment-productivity { fill: #57abff; }
+#segment-legacy { fill: #3d9eff; }
+
 .segment.highlight {
-    fill: #4da6ff;
-    opacity: 0.7;
+    fill: #4da6ff !important;
+    opacity: 0.9;
 }
 
 .segment-label {
@@ -44,4 +80,16 @@ body {
     font-size: 12px;
     display: none;
     pointer-events: none;
+}
+
+#curve-container {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    text-align: center;
+}
+
+#hype-curve {
+    max-width: 100%;
+    height: 200px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,14 +23,14 @@
             <rect id="segment-enlightenment" class="segment" x="400" y="0" width="100" height="300"></rect>
             <rect id="segment-productivity" class="segment" x="500" y="0" width="80" height="300"></rect>
             <rect id="segment-legacy" class="segment" x="580" y="0" width="20" height="300"></rect>
-            <path d="M0,200 Q50,50 100,150 T220,80 T340,220 T420,160 T540,200 T600,250" fill="none" stroke="#000" stroke-width="2" />
-            <text x="5" y="20" class="segment-label">Discovery Nascent Research</text>
-            <text x="85" y="20" class="segment-label">Early Exploration Technology Trigger</text>
-            <text x="170" y="20" class="segment-label">Peak of Inflated Expectations (Hype Peak)</text>
-            <text x="285" y="20" class="segment-label">Trough of Disillusionment (Shakeout)</text>
-            <text x="405" y="20" class="segment-label">Slope of Enlightenment Scaling Pilots</text>
-            <text x="505" y="20" class="segment-label">Plateau of Productivity (Mainstream)</text>
-            <text x="585" y="20" transform="rotate(90 585,20)" class="segment-label">Commoditized Legacy (Late Majority & Decline)</text>
+            <path d="M0,200 Q50,50 100,150 T220,80 T340,220 T420,160 T540,200 T600,250" fill="none" stroke="#0055aa" stroke-width="2" />
+            <text x="40" y="20" class="segment-label" text-anchor="middle">Discovery</text>
+            <text x="120" y="20" class="segment-label" text-anchor="middle">Tech Trigger</text>
+            <text x="220" y="20" class="segment-label" text-anchor="middle">Hype Peak</text>
+            <text x="340" y="20" class="segment-label" text-anchor="middle">Disillusionment</text>
+            <text x="450" y="20" class="segment-label" text-anchor="middle">Enlightenment</text>
+            <text x="540" y="20" class="segment-label" text-anchor="middle">Productivity</text>
+            <text x="590" y="20" transform="rotate(90 590,20)" class="segment-label" text-anchor="middle">Legacy</text>
         </svg>
     </div>
     <div id="tooltip"></div>


### PR DESCRIPTION
## Summary
- Center dialogue form and list, add float-in animation for technologies and clear input after submission.
- Display instruments via tooltip on hover and highlight chart segments.
- Refresh hype curve with colorful segments, improved labels, and fixed bottom positioning.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aea27defb88321b019791b52af398e