### PR TITLE
Add interactive Gartner maturity curve

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ TECHNOLOGIES = [
         "summary": "Learns relationships across multiple temporal periods for financial forecasting.",
         "instruments": ["Python", "R", "C++"],
         "sources": [],
+        "segment": "discovery",
     },
     {
         "id": "irf",
@@ -20,6 +21,7 @@ TECHNOLOGIES = [
         "summary": "Filters redundant signals between time periods.",
         "instruments": ["Python", "R", "C++"],
         "sources": [],
+        "segment": "trigger",
     },
     {
         "id": "lwi",
@@ -27,6 +29,7 @@ TECHNOLOGIES = [
         "summary": "Learns optimal weights to integrate forecasts from different periods.",
         "instruments": ["Python", "R", "C++"],
         "sources": [],
+        "segment": "peak",
     },
     {
         "id": "fusion",
@@ -34,6 +37,7 @@ TECHNOLOGIES = [
         "summary": "Combines heterogeneous signals/features across horizons.",
         "instruments": ["Python", "R", "C++"],
         "sources": [],
+        "segment": "trough",
     },
     {
         "id": "path-squeeze",
@@ -41,6 +45,7 @@ TECHNOLOGIES = [
         "summary": "Reduces dimensionality along temporal paths.",
         "instruments": ["Python", "R", "C++"],
         "sources": [],
+        "segment": "slope",
     },
 ]
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -36,3 +36,22 @@
 .toast.show {
   opacity: 1;
 }
+
+/* Gartner technology maturity curve */
+.gc-segment {
+  stroke: #94a3b8; /* slate-400 */
+  stroke-width: 4;
+  fill: none;
+  opacity: 0.3;
+  transition: stroke 0.2s ease, opacity 0.2s ease;
+}
+
+.gc-segment.active {
+  stroke: #14b8a6; /* teal-500 */
+  opacity: 1;
+}
+
+.gc-label {
+  font-size: 12px;
+  fill: currentColor;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -44,11 +44,24 @@ function renderResults(items) {
   items.forEach((item, i) => container.appendChild(createTechCard(item, i)));
 }
 
+// Highlight curve segment
+function highlightSegment(seg) {
+  const segments = document.querySelectorAll('#gartner-curve .gc-segment');
+  segments.forEach(s => s.classList.remove('active'));
+  if (seg) {
+    const target = document.getElementById(`gc-${seg}`);
+    if (target) target.classList.add('active');
+  }
+}
+
 // Create a technology card with accordion behavior and animation delay
 function createTechCard(item, index) {
   const card = document.createElement('div');
   card.className = 'rounded-2xl bg-white dark:bg-slate-900 shadow anim-float-in';
   card.style.animationDelay = `${index * 90}ms`;
+
+  card.addEventListener('mouseenter', () => highlightSegment(item.segment));
+  card.addEventListener('mouseleave', () => highlightSegment(null));
 
   const btn = document.createElement('button');
   btn.id = `acc-btn-${item.id}`;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,24 @@
         <button type="submit" class="px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-700 focus:outline-none focus-visible:ring-2 ring-teal-500">Submit</button>
     </form>
     <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
+    <div id="gartner-container" class="mt-8">
+        <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-64">
+            <path id="gc-discovery" class="gc-segment" d="M40 220 Q90 200 130 180" />
+            <path id="gc-trigger" class="gc-segment" d="M130 180 Q180 60 220 80" />
+            <path id="gc-peak" class="gc-segment" d="M220 80 Q240 60 260 90" />
+            <path id="gc-trough" class="gc-segment" d="M260 90 C300 260 330 200 360 220" />
+            <path id="gc-slope" class="gc-segment" d="M360 220 Q420 150 470 170" />
+            <path id="gc-plateau" class="gc-segment" d="M470 170 L560 170" />
+            <path id="gc-legacy" class="gc-segment" d="M560 170 Q610 190 650 210" />
+            <text x="70" y="260" class="gc-label">Discovery Nascent Research</text>
+            <text x="150" y="40" class="gc-label">Early Exploration Technology Trigger</text>
+            <text x="220" y="60" class="gc-label">Peak of Inflated Expectations</text>
+            <text x="300" y="280" class="gc-label">Trough of Disillusionment</text>
+            <text x="380" y="140" class="gc-label">Slope of Enlightenment</text>
+            <text x="480" y="150" class="gc-label">Plateau of Productivity</text>
+            <text x="580" y="230" class="gc-label">Commoditized Legacy</text>
+        </svg>
+    </div>
     <div id="results" class="mt-8 space-y-4"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add technology segment metadata to backend
- render Gartner technology maturity curve SVG with labelled segments
- highlight corresponding curve segment when hovering over technology cards

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb932806c8321bf093c79f906615d