### PR TITLE
Add markdown chat window above plot

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('question-form');
   const input = document.getElementById('question-input');
   const toggleBtn = document.getElementById('theme-toggle');
+  const chatWindow = document.getElementById('chat-window');
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -26,6 +27,47 @@ document.addEventListener('DOMContentLoaded', () => {
     const mode = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
     setTheme(mode);
   });
+
+  if (chatWindow) {
+    const markdownText = `
+## Технологии для предиктивной аналитики и их применение в улучшении продаж
+
+1. **Video marketing analytics with AI (AI-аналитика видео-маркетинга)**
+
+   * **Используемые инструменты:** RapidMiner, CatBoost, machine learning
+   * **Вклад в продажи:** Повышает точность прогнозирования эффективности маркетинговых кампаний через автоматическую обработку данных и сегментацию клиентов. Улучшает стратегическое планирование за счёт анализа поведения аудитории (Santos & Malta, 2023; Santos et al., 2024).
+
+2. **AI-technologies (ИИ-технологии)**
+
+   * **Используемые инструменты:** Natural language processing (NLP), machine learning
+   * **Вклад в продажи:** NLP автоматизирует обработку текстовых данных для выявления трендов, а ML обеспечивает прогностические инсайты и когнитивное принятие решений. Ускоряет адаптацию маркетинговых стратегий к запросам клиентов (Plata Lerma et al., 2023).
+
+3. **Predictive modeling for churn prevention (Прогнозная модель удержания клиентов)**
+
+   * **Используемые инструменты:** k-Nearest Neighbors (kNN)
+   * **Вклад в продажи:** Алгоритм классифицирует риски оттока клиентов, позволяя заранее внедрять персонализированные меры удержания. Снижает потери дохода за счёт раннего выявления проблемных сегментов (Sasse et al., 2025).
+
+4. **AI-driven digital marketing analytics (ИИ-аналитика цифрового маркетинга)**
+
+   * **Используемые инструменты:** Deep neural networks
+   * **Вклад в продажи:** Глубокие нейронные сети оптимизируют прогнозирование метрик эффективности рекламы, повышая точность таргетирования и ROI кампаний. Улучшают автоматизацию маркетинговых процессов (Wei et al., 2024).
+
+---
+
+### Список источников
+
+* Santos, V., & Malta, P. (2023). *The Impact of Digital Transformation on Innovation in European Companies*. ICMarkTech.
+* Santos, V., & Malta, P. (2024). *Evaluating the Impact of MarTech on Digital Transformation in EU Companies*. ICMarkTech.
+* Plata Lerma, D. F., Kwarteng, M. A., Ntsiful, A., Owusu, V. K., & Amankwah, E. S. (2023). *Beyond UTAUT: AI Adoption in SMEs*. SMA.
+* Sasse, L., Nicolaisen-Soberky, E., et al. (2025). *Overview of leakage scenarios in supervised machine learning*. *Journal of Big Data*. DOI: 10.1186/...
+* Wei, C., Zelditch, B., Chen, J., & Ribeiro, A. A. S. T. (2024). *Neural Optimization for Intelligent Marketing Systems*. KDD. DOI: 10.1145/3637528...
+`;
+    if (window.marked) {
+      chatWindow.innerHTML = window.marked.parse(markdownText);
+    } else {
+      chatWindow.textContent = markdownText;
+    }
+  }
 
   initTheme();
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,7 @@
     </main>
     <footer class="text-center text-sm py-4 text-slate-500 dark:text-slate-400">Prototype — example data only.</footer>
     <div id="toast" class="toast"></div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
         <button type="submit" class="px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-700 focus:outline-none focus-visible:ring-2 ring-teal-500">Submit</button>
     </form>
     <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
+    <div id="chat-window" class="mt-6 p-4 rounded-xl bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow max-h-96 overflow-y-auto text-sm"></div>
     <div id="gartner-container" class="mt-8">
         <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-64">
             <path id="gc-discovery" class="gc-segment" d="M40 220 Q90 200 130 180" />


### PR DESCRIPTION
## Summary
- show markdown-formatted filler text in a new chat window above the Gartner curve
- render markdown on the client using the marked.js CDN

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af52d8b6488321a3a408a9788e9238

## Summary by Sourcery

Add a chat window above the Gartner curve that displays predefined markdown content rendered client-side with marked.js.

New Features:
- Insert a new chat window div above the plot to show markdown-formatted filler text
- Load marked.js from a CDN to parse and render the markdown in the chat window

Enhancements:
- Provide a fallback to display raw markdown text if marked.js is unavailable