### PR TITLE
Animate chat window on matching question

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,35 +1,6 @@
 // Frontend logic for search, accordion, dark mode, and toasts
 
-document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('question-form');
-  const input = document.getElementById('question-input');
-  const toggleBtn = document.getElementById('theme-toggle');
-  const chatWindow = document.getElementById('chat-window');
-
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const q = input.value;
-    try {
-      const res = await fetch('/search', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ q })
-      });
-      const data = await res.json();
-      renderResults(data.items);
-      showToast('Results refreshed for your question.');
-    } catch (err) {
-      console.error(err);
-    }
-  });
-
-  toggleBtn.addEventListener('click', () => {
-    const mode = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-    setTheme(mode);
-  });
-
-  if (chatWindow) {
-    const markdownText = `
+const markdownText = `
 ## Технологии для предиктивной аналитики и их применение в улучшении продаж
 
 1. **Video marketing analytics with AI (AI-аналитика видео-маркетинга)**
@@ -62,12 +33,48 @@ document.addEventListener('DOMContentLoaded', () => {
 * Sasse, L., Nicolaisen-Soberky, E., et al. (2025). *Overview of leakage scenarios in supervised machine learning*. *Journal of Big Data*. DOI: 10.1186/...
 * Wei, C., Zelditch, B., Chen, J., & Ribeiro, A. A. S. T. (2024). *Neural Optimization for Intelligent Marketing Systems*. KDD. DOI: 10.1145/3637528...
 `;
-    if (window.marked) {
-      chatWindow.innerHTML = window.marked.parse(markdownText);
-    } else {
-      chatWindow.textContent = markdownText;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('question-form');
+  const input = document.getElementById('question-input');
+  const toggleBtn = document.getElementById('theme-toggle');
+  const chatWindow = document.getElementById('chat-window');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const q = input.value;
+    try {
+      const res = await fetch('/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ q })
+      });
+      const data = await res.json();
+      if (data.matched) {
+        if (window.marked) {
+          chatWindow.innerHTML = window.marked.parse(markdownText);
+        } else {
+          chatWindow.textContent = markdownText;
+        }
+        chatWindow.classList.remove('hidden');
+        chatWindow.classList.remove('anim-float-in');
+        void chatWindow.offsetWidth;
+        chatWindow.classList.add('anim-float-in');
+      } else {
+        chatWindow.classList.add('hidden');
+        chatWindow.innerHTML = '';
+      }
+      renderResults(data.items);
+      showToast('Results refreshed for your question.');
+    } catch (err) {
+      console.error(err);
     }
-  }
+  });
+
+  toggleBtn.addEventListener('click', () => {
+    const mode = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+    setTheme(mode);
+  });
 
   initTheme();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,8 @@
         <button type="submit" class="px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-700 focus:outline-none focus-visible:ring-2 ring-teal-500">Submit</button>
     </form>
     <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
-    <div id="chat-window" class="mt-6 p-4 rounded-xl bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow max-h-96 overflow-y-auto text-sm"></div>
+    <div id="chat-window" class="mt-4 p-4 rounded-xl bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow max-h-96 overflow-y-auto text-sm hidden"></div>
+    <div id="results" class="mt-8 space-y-4"></div>
     <div id="gartner-container" class="mt-8">
         <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-64">
             <path id="gc-discovery" class="gc-segment" d="M40 220 Q90 200 130 180" />
@@ -25,6 +26,5 @@
             <text x="580" y="230" class="gc-label">Commoditized Legacy</text>
         </svg>
     </div>
-    <div id="results" class="mt-8 space-y-4"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Position conversation window above results and move Gartner curve plot to the end of the page
- Hide chat window by default and reveal it with float-in animation when the submitted question matches the template
- Reset chat window when the query doesn't match

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5861b8e48321a77df197a0a980c5