### PR TITLE
Add delayed chart reveal and loading animation

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -39,17 +39,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('question-input');
   const toggleBtn = document.getElementById('theme-toggle');
   const chatWindow = document.getElementById('chat-window');
+  const loading = document.getElementById('loading');
+  const gartnerContainer = document.getElementById('gartner-container');
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const q = input.value;
     try {
-      const res = await fetch('/search', {
+      chatWindow.classList.add('hidden');
+      chatWindow.innerHTML = '';
+      gartnerContainer.classList.add('hidden');
+      loading.classList.remove('hidden');
+
+      const resPromise = fetch('/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ q })
-      });
-      const data = await res.json();
+      }).then(r => r.json());
+      await Promise.all([resPromise, new Promise(r => setTimeout(r, 5000))]);
+      const data = await resPromise;
+      loading.classList.add('hidden');
       if (data.matched) {
         if (window.marked) {
           chatWindow.innerHTML = window.marked.parse(markdownText);
@@ -60,14 +69,20 @@ document.addEventListener('DOMContentLoaded', () => {
         chatWindow.classList.remove('anim-float-in');
         void chatWindow.offsetWidth;
         chatWindow.classList.add('anim-float-in');
+        gartnerContainer.classList.remove('hidden');
+        gartnerContainer.classList.remove('anim-float-in');
+        void gartnerContainer.offsetWidth;
+        gartnerContainer.classList.add('anim-float-in');
       } else {
         chatWindow.classList.add('hidden');
         chatWindow.innerHTML = '';
+        gartnerContainer.classList.add('hidden');
       }
       renderResults(data.items);
       showToast('Results refreshed for your question.');
     } catch (err) {
       console.error(err);
+      loading.classList.add('hidden');
     }
   });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,14 @@
     </form>
     <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
     <div id="chat-window" class="mt-4 p-4 rounded-xl bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow max-h-96 overflow-y-auto text-sm hidden"></div>
+    <div id="loading" class="mt-4 text-center hidden">
+        <svg class="animate-spin h-8 w-8 text-teal-600 mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+    </div>
     <div id="results" class="mt-8 space-y-4"></div>
-    <div id="gartner-container" class="mt-8">
+    <div id="gartner-container" class="mt-8 hidden">
         <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-64">
             <path id="gc-discovery" class="gc-segment" d="M40 220 Q90 200 130 180" />
             <path id="gc-trigger" class="gc-segment" d="M130 180 Q180 60 220 80" />


### PR DESCRIPTION
## Summary
- Hide Gartner curve until predefined question matches and display with float-in animation
- Show 5-second spinner after form submission before revealing results and chart

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68afdcbb2170832198801092d8b27e09