### PR TITLE
Redesign layout with responsive technology and plot panels

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,21 +1,25 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="max-w-4xl mx-auto p-4 md:p-6 lg:p-8">
-    <form id="question-form" class="space-y-4">
-        <input id="question-input" type="text" name="q" class="w-full text-lg p-4 rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 focus:outline-none focus-visible:ring-2 ring-teal-500" placeholder="Ask your question…" />
-        <button type="submit" class="px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-700 focus:outline-none focus-visible:ring-2 ring-teal-500">Submit</button>
-    </form>
-    <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
-    <div id="loading" class="mt-4 text-center hidden">
-        <svg class="animate-spin h-8 w-8 text-teal-600 mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-        </svg>
+<div class="w-full h-full flex flex-col md:flex-row gap-4 p-4 md:p-6">
+    <!-- Left Panel -->
+    <div class="w-full md:w-3/5 bg-white dark:bg-slate-900 rounded-xl shadow-sm flex flex-col p-4">
+        <form id="question-form" class="space-y-4">
+            <input id="question-input" type="text" name="q" class="w-full text-lg p-4 rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 focus:outline-none focus-visible:ring-2 ring-teal-500" placeholder="Ask your question…" />
+            <button type="submit" class="px-6 py-3 rounded-xl bg-teal-600 text-white hover:bg-teal-700 focus:outline-none focus-visible:ring-2 ring-teal-500">Submit</button>
+        </form>
+        <p class="mt-4 text-sm text-slate-500 dark:text-slate-400">Try asking the specific question about AI technologies for multi-period forecasting.</p>
+        <div id="loading" class="mt-4 text-center hidden">
+            <svg class="animate-spin h-8 w-8 text-teal-600 mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+            </svg>
+        </div>
+        <div id="results" class="mt-6 flex-1 overflow-y-auto scroll-smooth space-y-4"></div>
     </div>
-    <div class="mt-8 flex flex-col lg:flex-row lg:items-start gap-8">
-        <div id="results" class="flex-1 space-y-4"></div>
-        <div id="gartner-container" class="hidden lg:w-1/3 lg:sticky lg:top-1/2 lg:-translate-y-1/2">
-            <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-64">
+    <!-- Right Panel -->
+    <div class="w-full md:w-2/5 bg-white dark:bg-slate-900 rounded-xl shadow-sm flex items-center justify-center p-4">
+        <div id="gartner-container" class="w-full h-full flex items-center justify-center hidden">
+            <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-auto max-h-full">
                 <path id="gc-discovery" class="gc-segment" d="M40 220 Q90 200 130 180" />
                 <path id="gc-trigger" class="gc-segment" d="M130 180 Q180 60 220 80" />
                 <path id="gc-peak" class="gc-segment" d="M220 80 Q240 60 260 90" />


### PR DESCRIPTION
## Summary
- Split main page into responsive two-panel layout: technology list on the left (~60%) and plot on the right (~40%) with vertical stacking on small screens.
- Keep question form fixed at top of left panel, add scrollable area for technology cards, and apply minimalist styling with rounded corners and subtle shadows.
- Center plot within right panel, ensuring it scales to fill available space while maintaining aspect ratio.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68b3fc3ee8748321b4acbac5ca06374f