### PR TITLE
Enhance Gartner curve with D3 smoothing and layout fixes

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -53,6 +53,7 @@
   stroke: black;
   stroke-width: 1;
   pointer-events: none;
+  transition: x1 0.4s ease, x2 0.4s ease;
 }
 
 #stage-overlay {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -148,11 +148,18 @@ function initGartnerCurve() {
     [560, 150],
     [650, 200],
   ];
-  const curvePath = catmullRom2bezier(points);
+  const line = d3.line().curve(d3.curveCatmullRom.alpha(0.5));
+  const curvePath = line(points);
   const curve = document.getElementById('gc-curve-path');
   curve.setAttribute('d', curvePath);
 
-  const areaPath = `${curvePath} L${points[points.length - 1][0]} ${BASELINE} L${points[0][0]} ${BASELINE} Z`;
+  const area = d3
+    .area()
+    .curve(d3.curveCatmullRom.alpha(0.5))
+    .x((d) => d[0])
+    .y0(BASELINE)
+    .y1((d) => d[1]);
+  const areaPath = area(points);
   const maskPath = document.getElementById('mask-path');
   maskPath.setAttribute('d', areaPath);
 
@@ -164,23 +171,6 @@ function initGartnerCurve() {
   leftLine = document.getElementById('stage-left');
   rightLine = document.getElementById('stage-right');
   descPanel = document.getElementById('stage-description');
-}
-
-function catmullRom2bezier(points) {
-  let d = `M${points[0][0]} ${points[0][1]}`;
-  for (let i = 0; i < points.length - 1; i++) {
-    const p0 = points[i - 1] || points[i];
-    const p1 = points[i];
-    const p2 = points[i + 1];
-    const p3 = points[i + 2] || p2;
-
-    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
-    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
-    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
-    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
-    d += ` C${c1x} ${c1y} ${c2x} ${c2y} ${p2[0]} ${p2[1]}`;
-  }
-  return d;
 }
 
 // Create a technology card with accordion behavior and animation delay

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,7 @@
     <footer class="text-center text-sm py-4 text-slate-500 dark:text-slate-400">Prototype — example data only.</footer>
     <div id="toast" class="toast"></div>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,16 +48,17 @@
                 <rect id="stage-overlay" x="0" y="0" width="700" height="260" fill="url(#stage-gradient)"
                     clip-path="url(#stage-clip)" mask="url(#stage-mask)" visibility="hidden" aria-hidden="true"></rect>
                 <path id="gc-curve-path" class="gc-curve" d=""></path>
-                <line id="stage-left" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true">
-                </line>
-                <line id="stage-right" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true">
-                </line>
-                <text x="80" y="260" class="gc-label">Technology Trigger</text>
-                <text x="170" y="40" class="gc-label">Peak of Inflated Expectations</text>
+                <line id="stage-left" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true"
+                    clip-path="url(#stage-clip)" mask="url(#stage-mask)" stroke-opacity="1"></line>
+                <line id="stage-right" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true"
+                    clip-path="url(#stage-clip)" mask="url(#stage-mask)" stroke-opacity="1"></line>
+                <text x="20" y="245" class="gc-label">Discovery / Nascent Research</text>
+                <text x="140" y="260" class="gc-label">Technology Trigger</text>
+                <text x="170" y="30" class="gc-label">Peak of Inflated Expectations</text>
                 <text x="260" y="280" class="gc-label">Trough of Disillusionment</text>
                 <text x="360" y="150" class="gc-label">Slope of Enlightenment</text>
-                <text x="500" y="150" class="gc-label">Plateau of Productivity</text>
-                <text x="600" y="230" class="gc-label">Commoditized Legacy</text>
+                <text x="500" y="130" class="gc-label">Plateau of Productivity</text>
+                <text x="540" y="220" class="gc-label">Commoditized Legacy</text>
             </svg>
         </div>
         <div id="stage-description" class="mt-4 text-base font-medium text-green-700" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- Smooth Gartner curve using D3 line and area generators
- Add discovery label and reposition texts so phrases fit without overlap
- Clip and animate stage boundary lines under curve

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b53bf0acc083219d3da2ffd62b348f

## Summary by Sourcery

Enhance the Gartner curve visualization by leveraging D3 for smoothing and area generation, animating boundary lines, and repositioning labels for improved layout.

New Features:
- Smooth Gartner curve and area fill using D3 line and area generators with Catmull-Rom interpolation
- Clip and animate stage boundary lines under the curve with mask and transition effects

Enhancements:
- Add “Discovery / Nascent Research” stage label and adjust positions of existing labels to prevent overlaps
- Remove custom catmullRom2bezier implementation in favor of D3 functions
- Include D3 v7 script as a dependency