### PR TITLE
Align maturity stage highlights with curve

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,14 +1,14 @@
 // Frontend logic for search, accordion, dark mode, and toasts
 
-const BASELINE = 260;
+const BASELINE = 600;
 const STAGE_RANGES = {
-  discovery: [40, 130],
-  trigger: [130, 220],
-  peak: [220, 260],
-  trough: [260, 360],
-  slope: [360, 470],
-  plateau: [470, 560],
-  legacy: [560, 650],
+  discovery: [100, 250],
+  trigger: [250, 480],
+  peak: [480, 650],
+  trough: [650, 860],
+  slope: [860, 1020],
+  plateau: [1020, 1120],
+  legacy: [1120, 1200],
 };
 
 const stageDescriptions = {
@@ -134,32 +134,11 @@ function highlightSegment(seg) {
 }
 
 function initGartnerCurve() {
-  const points = [
-    [40, 260],
-    [110, 200],
-    [150, 100],
-    [170, 40],
-    [190, 100],
-    [240, 240],
-    [260, 260],
-    [280, 240],
-    [360, 180],
-    [470, 150],
-    [560, 150],
-    [650, 200],
-  ];
-  const line = d3.line().curve(d3.curveCatmullRom.alpha(0.5));
-  const curvePath = line(points);
+  const curvePath =
+    "M100 450 C180 420, 220 360, 280 300 C340 220, 420 140, 480 140 C540 140, 600 240, 650 370 C700 440, 780 360, 860 330 C940 310, 1020 320, 1080 340 S1140 380, 1120 360";
+  const areaPath = `${curvePath} L1120 ${BASELINE} L100 ${BASELINE} Z`;
   const curve = document.getElementById('gc-curve-path');
   curve.setAttribute('d', curvePath);
-
-  const area = d3
-    .area()
-    .curve(d3.curveCatmullRom.alpha(0.5))
-    .x((d) => d[0])
-    .y0(BASELINE)
-    .y1((d) => d[1]);
-  const areaPath = area(points);
   const maskPath = document.getElementById('mask-path');
   maskPath.setAttribute('d', areaPath);
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
     <section
         class="bg-white border border-slate-200 rounded-xl p-6 flex flex-col items-center justify-center min-h-[70vh]">
         <div id="gartner-container" class="w-full h-full flex items-center justify-center hidden">
-            <svg id="gartner-curve" viewBox="0 0 700 300" class="w-full h-auto max-h-full" role="img"
+            <svg id="gartner-curve" viewBox="0 0 1200 600" class="w-full h-auto max-h-full" role="img"
                 aria-label="Technology hype cycle curve">
                 <defs>
                     <linearGradient id="stage-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -39,26 +39,35 @@
                         <stop offset="100%" stop-color="green" stop-opacity="0.4" />
                     </linearGradient>
                     <clipPath id="stage-clip">
-                        <rect id="stage-clip-rect" x="0" y="0" width="0" height="260"></rect>
+                        <rect id="stage-clip-rect" x="0" y="0" width="0" height="600"></rect>
                     </clipPath>
                     <mask id="stage-mask">
                         <path id="mask-path" d="" fill="white"></path>
                     </mask>
                 </defs>
-                <rect id="stage-overlay" x="0" y="0" width="700" height="260" fill="url(#stage-gradient)"
+                <rect id="stage-overlay" x="0" y="0" width="1200" height="600" fill="url(#stage-gradient)"
                     clip-path="url(#stage-clip)" mask="url(#stage-mask)" visibility="hidden" aria-hidden="true"></rect>
                 <path id="gc-curve-path" class="gc-curve" d=""></path>
-                <line id="stage-left" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true"
+                <line id="stage-left" class="stage-boundary" y1="0" y2="600" visibility="hidden" aria-hidden="true"
                     clip-path="url(#stage-clip)" mask="url(#stage-mask)" stroke-opacity="1"></line>
-                <line id="stage-right" class="stage-boundary" y1="0" y2="260" visibility="hidden" aria-hidden="true"
+                <line id="stage-right" class="stage-boundary" y1="0" y2="600" visibility="hidden" aria-hidden="true"
                     clip-path="url(#stage-clip)" mask="url(#stage-mask)" stroke-opacity="1"></line>
-                <text x="20" y="245" class="gc-label">Discovery / Nascent Research</text>
-                <text x="140" y="260" class="gc-label">Technology Trigger</text>
-                <text x="170" y="30" class="gc-label">Peak of Inflated Expectations</text>
-                <text x="260" y="280" class="gc-label">Trough of Disillusionment</text>
-                <text x="360" y="150" class="gc-label">Slope of Enlightenment</text>
-                <text x="500" y="130" class="gc-label">Plateau of Productivity</text>
-                <text x="540" y="220" class="gc-label">Commoditized Legacy</text>
+                <!-- Stage Markers -->
+                <circle cx="100" cy="450" r="5" fill="#000"></circle>
+                <circle cx="250" cy="300" r="5" fill="#000"></circle>
+                <circle cx="480" cy="140" r="5" fill="#000"></circle>
+                <circle cx="650" cy="370" r="5" fill="#000"></circle>
+                <circle cx="860" cy="330" r="5" fill="#000"></circle>
+                <circle cx="1020" cy="320" r="5" fill="#000"></circle>
+                <circle cx="1120" cy="360" r="5" fill="#000"></circle>
+                <!-- Labels -->
+                <text x="30" y="470" class="gc-label">Discovery / Nascent Research</text>
+                <text x="180" y="280" class="gc-label">Technology Trigger</text>
+                <text x="400" y="115" class="gc-label">Peak of Inflated Expectations</text>
+                <text x="590" y="425" class="gc-label">Trough of Disillusionment</text>
+                <text x="780" y="310" class="gc-label">Slope of Enlightenment</text>
+                <text x="940" y="295" class="gc-label">Plateau of Productivity</text>
+                <text x="1000" y="390" class="gc-label">Commoditized Legacy</text>
             </svg>
         </div>
         <div id="stage-description" class="mt-4 text-base font-medium text-green-700" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- embed provided smooth Gartner hype curve SVG with stage markers and labels
- expand highlight ranges to match updated curve coordinates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b543263da08321ba33010d5082b265