### PR TITLE
Remove dark mode toggle

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,4 @@
-// Frontend logic for search, accordion, dark mode, and toasts
+// Frontend logic for search, accordion, and toasts
 
 const BASELINE = 600;
 const STAGE_RANGES = {
@@ -33,7 +33,6 @@ let overlay, clipRect, leftLine, rightLine, descPanel;
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('question-form');
   const input = document.getElementById('question-input');
-  const toggleBtn = document.getElementById('theme-toggle');
   const loading = document.getElementById('loading');
   const results = document.getElementById('results');
   const gartnerContainer = document.getElementById('gartner-container');
@@ -78,12 +77,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  toggleBtn.addEventListener('click', () => {
-    const mode = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-    setTheme(mode);
-  });
-
-  initTheme();
   initGartnerCurve();
 });
 
@@ -191,7 +184,7 @@ function createTechCard(item, index) {
       ${item.instruments
       .map(
         (i) =>
-          `<span class="px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 dark:bg-teal-800 dark:text-teal-100 text-xs">${i}</span>`
+          `<span class="px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 text-xs">${i}</span>`
       )
       .join('')}
     </div>`;
@@ -204,7 +197,7 @@ function createTechCard(item, index) {
         ${item.sources
         .map(
           (s) =>
-            `<li><a href="${s.url}" target="_blank" class="underline text-teal-600 dark:text-teal-400">${s.name}</a></li>`
+            `<li><a href="${s.url}" target="_blank" class="underline text-teal-600">${s.name}</a></li>`
         )
         .join('')}
       </ul>`;
@@ -254,36 +247,6 @@ function toggleAccordion(id) {
     targetChevron.style.transform = 'rotate(180deg)';
   }
 }
-
-// Theme utilities
-function setTheme(mode) {
-  const root = document.documentElement;
-  if (mode === 'dark') {
-    root.classList.add('dark');
-  } else {
-    root.classList.remove('dark');
-  }
-  localStorage.setItem('theme', mode);
-  updateThemeIcons(mode);
-}
-
-function initTheme() {
-  const stored = localStorage.getItem('theme');
-  setTheme(stored === 'dark' ? 'dark' : 'light');
-}
-
-function updateThemeIcons(mode) {
-  const sun = document.getElementById('icon-sun');
-  const moon = document.getElementById('icon-moon');
-  if (mode === 'dark') {
-    sun.classList.remove('hidden');
-    moon.classList.add('hidden');
-  } else {
-    sun.classList.add('hidden');
-    moon.classList.remove('hidden');
-  }
-}
-
 // Simple toast/snackbar
 function showToast(message) {
   const toast = document.getElementById('toast');

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,25 +10,9 @@
     <script>window.CSRF_OFF = "true";</script>
 </head>
 
-<body class="min-h-dvh bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 flex flex-col">
-    <header class="flex items-center justify-between px-4 py-3 shadow-sm bg-white dark:bg-slate-900">
+<body class="min-h-dvh bg-slate-50 text-slate-900 flex flex-col">
+    <header class="flex items-center px-4 py-3 shadow-sm bg-white">
         <h1 class="text-xl font-semibold">AI Форсайт</h1>
-        <button id="theme-toggle"
-            class="p-2 rounded-full focus:outline-none focus-visible:ring-2 ring-teal-500 dark:ring-offset-slate-900"
-            aria-label="Toggle dark mode">
-            <svg id="icon-sun" class="w-6 h-6 hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                fill="currentColor">
-                <path d="M12 18a6 6 0 100-12 6 6 0 000 12z" />
-                <path fill-rule="evenodd"
-                    d="M12 2a.75.75 0 01.75.75V5a.75.75 0 01-1.5 0V2.75A.75.75 0 0112 2zm0 14.5a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-3.75a.75.75 0 01.75-.75zm9.25-5.75a.75.75 0 01-.75.75H17a.75.75 0 010-1.5h3.5a.75.75 0 01.75.75zM7 12a.75.75 0 01-.75.75H2.75a.75.75 0 010-1.5H6.25A.75.75 0 017 12zm10.78-6.78a.75.75 0 010 1.06L16.06 9a.75.75 0 01-1.06-1.06l1.72-1.72a.75.75 0 011.06 0zm-9.56 9.56a.75.75 0 010 1.06L6.5 19.94a.75.75 0 11-1.06-1.06l1.72-1.72a.75.75 0 011.06 0zm11.12 0a.75.75 0 00-1.06 0l-1.72 1.72a.75.75 0 101.06 1.06l1.72-1.72a.75.75 0 000-1.06zm-9.56-9.56a.75.75 0 00-1.06 0L6.5 6.5a.75.75 0 101.06 1.06l1.72-1.72a.75.75 0 000-1.06z"
-                    clip-rule="evenodd" />
-            </svg>
-            <svg id="icon-moon" class="w-6 h-6 hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                fill="currentColor">
-                <path
-                    d="M21.752 15.002A9.718 9.718 0 0112 21.75 9.75 9.75 0 0112 2.25c.54 0 1.076.043 1.607.128a.75.75 0 01.258 1.36 7.25 7.25 0 008.397 11.264.75.75 0 01.49 1.35z" />
-            </svg>
-        </button>
     </header>
     <main class="flex-1">
         {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- remove dark mode toggle button from base template
- strip dark theme code and classes from frontend script

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6553e7a0883218b1df5fc88ce3e27

## Summary by Sourcery

Remove dark mode functionality and associated UI elements

Enhancements:
- Remove theme toggle button and related JS utilities (setTheme, initTheme, updateThemeIcons)
- Strip dark mode CSS classes from base template, tech cards, and links